### PR TITLE
CMake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(QEFI
 )
 add_library(QEFI::QEFI ALIAS QEFI)
 set_target_properties(QEFI PROPERTIES PUBLIC_HEADER qefi.h)
-target_link_libraries(QEFI PRIVATE Qt${QT_VERSION_MAJOR}::Core)
+target_link_libraries(QEFI PUBLIC Qt${QT_VERSION_MAJOR}::Core)
 target_compile_definitions(QEFI PRIVATE QEFI_LIBRARY)
 
 find_package(PkgConfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,20 +19,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(QEFIVAR_LIB)
 set(QEFIVAR_INCLUDE)
+find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
+
+add_library(QEFI
+    qefi.cpp
+    qefi.h
+)
+add_library(QEFI::QEFI ALIAS QEFI)
+set_target_properties(QEFI PROPERTIES PUBLIC_HEADER qefi.h)
+target_link_libraries(QEFI PRIVATE Qt${QT_VERSION_MAJOR}::Core)
+target_compile_definitions(QEFI PRIVATE QEFI_LIBRARY)
 
 find_package(PkgConfig)
 if(PkgConfig_FOUND)
     pkg_check_modules(EFIVAR efivar)
 endif()
-
-find_package(QT NAMES Qt6 Qt5 COMPONENTS Core REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core REQUIRED)
-
-add_library(QEFI SHARED
-  qefi.cpp
-  qefi.h
-)
-set_target_properties(QEFI PROPERTIES PUBLIC_HEADER qefi.h)
 
 if(EFIVAR_FOUND)
     message("Use libefivar for EFI operations")
@@ -42,18 +44,20 @@ elseif(WIN32)
     message("Use Windows API for EFI operations")
     # TODO: Add include and lib from Windows API
 else()
-    message(FATAL_ERROR "No EFI utility found, please make sure you have libefivar installed")
+    message(FATAL_ERROR "No EFI utility library found, please make sure you have libefivar installed")
 endif()
 
-target_link_libraries(QEFI PRIVATE Qt${QT_VERSION_MAJOR}::Core)
+install(
+    TARGETS QEFI
+    EXPORT QEFITargets
+    PUBLIC_HEADER
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+)
 
-target_compile_definitions(QEFI PRIVATE QEFI_LIBRARY)
-
-install(TARGETS QEFI EXPORT QEFITargets PUBLIC_HEADER
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
-install(EXPORT QEFITargets
-        FILE QEFITargets.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QEFI
+install(
+    EXPORT QEFITargets
+    FILE QEFITargets.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QEFI
 )
 
 if(BUILD_TESTING)
@@ -61,6 +65,7 @@ if(BUILD_TESTING)
 endif()
 
 include(CMakePackageConfigHelpers)
+
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/QEFIConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfig.cmake
@@ -68,10 +73,15 @@ configure_package_config_file(
 )
 
 write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfigVersion.cmake
-  VERSION ${QEFI_VERSION}
-  COMPATIBILITY SameMajorVersion)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/QEFI
+    ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfigVersion.cmake
+    VERSION ${QEFI_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/QEFIConfigVersion.cmake
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/cmake/QEFI
 )


### PR DESCRIPTION
some CMake cleanup works

- removed `SHARED` from QEFI library (let `BUILD_SHARED_LIBS` decide)
- added an alias library `QEFI::QEFI` when used by downstream.
- unified tab size
- made `Qt::* libraries` linkage public